### PR TITLE
Add (un)install targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CC = clang
 CFLAGS = -Wall -pedantic -std=c99
 
 OBJECTS = $(filter-out main.o,$(patsubst %.c,%.o,$(wildcard *.c)))
-# OTHER = strconst.h
 BIN = fdstat
+PREFIX = /usr/bin
 
 ifdef DEBUG
 CFLAGS += -DDEBUG -g
@@ -18,6 +18,11 @@ $(BIN): main.c $(OBJECTS)
 %.o: %.c %.h $(OTHER)
 	$(CC) -c $(CFLAGS) $< -o $@
 
+install: $(BIN)
+	install -D -m 0755 $(BIN) $(DESTDIR)$(PREFIX)/$(BIN)
+
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/$(BIN)
 
 clean:
 	rm -fr $(BIN) *.o

--- a/debian/files
+++ b/debian/files
@@ -1,2 +1,2 @@
-fdstat_0.1.0-1_amd64.buildinfo admin optional
-fdstat_0.1.0-1_amd64.deb admin optional
+fdstat_0.1.1-1_amd64.buildinfo admin optional
+fdstat_0.1.1-1_amd64.deb admin optional


### PR DESCRIPTION
Resolves #6 

## Test plan
`make install` -- binary installed to `/usr/bin`
`make uninstall` -- binary removed from `/usr/bin`
`make debian` -- Debian package successfully built using 

## Proposed Changes
  * Add `install`/`uninstall` targets
  * Use `$(DESTDIR)` on both targets as some tools used by `dpkg-buildpackage` (namely `dh_auto_install`) use it and call the `install`/`uninstall` targets when a `Makefile` is available